### PR TITLE
feat: add cassandra and elasticsearch connectivity tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "example-self-hosted-saas-app",
       "version": "0.1.0",
       "dependencies": {
+        "@elastic/elasticsearch": "^9.0.2",
+        "cassandra-driver": "^4.8.0",
         "next": "15.3.3",
         "pg": "^8.16.3",
         "react": "^19.0.0",
@@ -48,6 +50,36 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@elastic/elasticsearch": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@elastic/elasticsearch/-/elasticsearch-9.0.2.tgz",
+      "integrity": "sha512-uKA0PuPSND3OhHH9UFqnKZfxifAg/8mQW4VnrQ+sUtusTbPhGuErs5NeWCPyd/RLgruBWBmLSv1zzEv5GS+UnA==",
+      "dependencies": {
+        "@elastic/transport": "^9.0.1",
+        "apache-arrow": "18.x - 19.x",
+        "tslib": "^2.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@elastic/transport": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/@elastic/transport/-/transport-9.0.2.tgz",
+      "integrity": "sha512-7okzzK9wP+qIFAw49/jAFYYHpJHBsDYfFt6dI2OBU8PRHEFCBqAPErTH5GBtgrs6rx/U1798kton5Ofv/tIHdw==",
+      "dependencies": {
+        "@opentelemetry/api": "1.x",
+        "debug": "^4.4.1",
+        "hpagent": "^1.2.0",
+        "ms": "^2.1.3",
+        "secure-json-parse": "^4.0.0",
+        "tslib": "^2.8.1",
+        "undici": "^7.10.0"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@emnapi/runtime": {
@@ -656,6 +688,14 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -947,11 +987,20 @@
         "tailwindcss": "4.1.8"
       }
     },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw=="
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg=="
+    },
     "node_modules/@types/node": {
       "version": "20.17.52",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.17.52.tgz",
       "integrity": "sha512-2aj++KfxubvW/Lc0YyXE3OEW7Es8TWn1MsRzYgcOGyTNQxi0L8rxQUCZ7ZbyOBWZQD5I63PV9egZWMsapVaklg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.19.2"
@@ -988,6 +1037,55 @@
         "@types/react": "^19.0.0"
       }
     },
+    "node_modules/adm-zip": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
+      "integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/apache-arrow": {
+      "version": "19.0.1",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-19.0.1.tgz",
+      "integrity": "sha512-APmMLzS4qbTivLrPdQXexGM4JRr+0g62QDaobzEvip/FdQIrv2qLy0mD5Qdmw4buydtVJgbFeKR8f59I6PPGDg==",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^20.13.0",
+        "command-line-args": "^6.0.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^24.3.25",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.js"
+      }
+    },
+    "node_modules/array-back": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.2.tgz",
+      "integrity": "sha512-gUAZ7HPyb4SJczXAMUXMGAvI976JoK3qEx9v1FTmeYuJj0IBiaKttG1ydtGKdkfqWkIkouke7nG8ufGy77+Cvw==",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/busboy": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
@@ -1018,6 +1116,61 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/cassandra-driver": {
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/cassandra-driver/-/cassandra-driver-4.8.0.tgz",
+      "integrity": "sha512-HritfMGq9V7SuESeSodHvArs0mLuMk7uh+7hQK2lqdvXrvm50aWxb4RPxkK3mPDdsgHjJ427xNRFITMH2ei+Sw==",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "adm-zip": "~0.5.10",
+        "long": "~5.2.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cassandra-driver/node_modules/@types/node": {
+      "version": "18.19.113",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.113.tgz",
+      "integrity": "sha512-TmSTE9vyebJ9vSEiU+P+0Sp4F5tMgjiEOZaQUW6wA3ODvi6uBgkHQ+EsIu0pbiKvf9QHEvyRCiaz03rV0b+IaA==",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/cassandra-driver/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
     },
     "node_modules/chownr": {
       "version": "3.0.0",
@@ -1054,7 +1207,6 @@
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -1066,8 +1218,7 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/color-string": {
       "version": "1.9.1",
@@ -1080,12 +1231,64 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "node_modules/command-line-args": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.1.tgz",
+      "integrity": "sha512-Jr3eByUjqyK0qd8W0SGFW1nZwqCaNCtbXjRo2cRJC1OYxWl3MZ5t1US3jq+cO4sPavqgw4l9BMGX0CBe+trepg==",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "find-replace": "^5.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^7.2.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.3.tgz",
+      "integrity": "sha512-PqMLy5+YGwhMh1wS04mVG44oqDsgyLRSKJBdOo1bnYhMKBW65gZF1dRp2OZRhiTjgUHljy99qkO7bsctLaw35Q==",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.0",
+        "typical": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.0.4",
@@ -1111,12 +1314,49 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/find-replace": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/flatbuffers": {
+      "version": "24.12.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-24.12.23.tgz",
+      "integrity": "sha512-dLVCAISd5mhls514keQzmEG6QHmUUsNuWsb4tFafIUwvvgDjXhtfAYSKOzt5SWOy+qByV5pbsDZ+Vb7HUOBEdA=="
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hpagent": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/hpagent/-/hpagent-1.2.0.tgz",
+      "integrity": "sha512-A91dYTeIB6NoXG+PxTQpCCDDnfHsW9kc06Lvpu1TEe9gnd6ZFeiBoRO9JvzEv6xK7EX97/dUE8g/vBMTqTS3CA==",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/is-arrayish": {
       "version": "0.3.2",
@@ -1133,6 +1373,14 @@
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/lightningcss": {
@@ -1374,6 +1622,16 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA=="
+    },
+    "node_modules/long": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.2.5.tgz",
+      "integrity": "sha512-e0r9YBBgNCq1D1o5Dp8FMH0N5hsFtXDBiVa0qoJPHpakvZkmDKPRoGffZJII/XsHvj9An9blm+cRJ01yQqU+Dw=="
+    },
     "node_modules/magic-string": {
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
@@ -1422,6 +1680,11 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -1701,6 +1964,21 @@
       "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
       "license": "MIT"
     },
+    "node_modules/secure-json-parse": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.0.0.tgz",
+      "integrity": "sha512-dxtLJO6sc35jWidmLxo7ij+Eg48PM/kleBsxpC8QJE0qJICe+KawkDQmvCMZUr9u7WKVHgMW6vy3fQ7zMiFZMA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ]
+    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -1814,6 +2092,29 @@
         }
       }
     },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.8.tgz",
@@ -1869,12 +2170,35 @@
         "node": ">=14.17"
       }
     },
+    "node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.11.0.tgz",
+      "integrity": "sha512-heTSIac3iLhsmZhUCjyS3JQEkZELateufzZuBaVM5RHXdSBMb1LPMQf5x+FH7qjsZYDP0ttAc3nnVpUB+wYbOg==",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
       "version": "6.19.8",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
       "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.0.tgz",
+      "integrity": "sha512-JNjcULU2e4KJwUNv6CHgI46UvDGitb6dGryHajXTDiLgg1/RiGoPSDw4kZfYnwGtEXf2ZMeIewDQgFGzkCB2Sg==",
+      "engines": {
+        "node": ">=12.17"
+      }
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@elastic/elasticsearch": "^9.0.2",
+    "cassandra-driver": "^4.8.0",
     "next": "15.3.3",
     "pg": "^8.16.3",
     "react": "^19.0.0",

--- a/src/app/api/cassandratest/route.ts
+++ b/src/app/api/cassandratest/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import cassandra from 'cassandra-driver';
+
+export async function GET() {
+    const client = new cassandra.Client({
+        contactPoints: [process.env.CASSANDRA_HOST || 'localhost'],
+        localDataCenter: 'datacenter1',
+        credentials: {
+            username: process.env.CASSANDRA_USER!,
+            password: process.env.CASSANDRA_PASSWORD!
+        },
+        keyspace: process.env.CASSANDRA_KEYSPACE
+    });
+
+    try {
+        await client.connect();
+        const result = await client.execute('SELECT * FROM system.local');
+        await client.shutdown();
+        return NextResponse.json({
+            message: 'Cassandra connection successful!',
+            dbResult: result.rows,
+            status: 'success',
+            timestamp: new Date().toISOString(),
+        });
+    } catch (error: any) {
+        return NextResponse.json({
+            message: 'Cassandra connection failed',
+            error: error && (error.stack || JSON.stringify(error)),
+            status: 'error',
+            timestamp: new Date().toISOString(),
+        }, { status: 500 });
+    }
+}

--- a/src/app/api/elastictest/route.ts
+++ b/src/app/api/elastictest/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from 'next/server';
+import { Client } from '@elastic/elasticsearch';
+
+export async function GET() {
+    const client = new Client({
+        node: `http${process.env.ELASTICSEARCH_SECURE === 'true' ? 's' : ''}://${process.env.ELASTICSEARCH_HOST}:${process.env.ELASTICSEARCH_PORT}`,
+        auth: {
+            username: process.env.ELASTICSEARCH_USER!,
+            password: process.env.ELASTICSEARCH_PASSWORD!
+        }
+    });
+
+    try {
+        const result = await client.info();
+        return NextResponse.json({
+            message: 'Elasticsearch connection successful!',
+            dbResult: result,
+            status: 'success',
+            timestamp: new Date().toISOString(),
+        });
+    } catch (error: any) {
+        return NextResponse.json({
+            message: 'Elasticsearch connection failed',
+            error: error && (error.stack || JSON.stringify(error)),
+            status: 'error',
+            timestamp: new Date().toISOString(),
+        }, { status: 500 });
+    }
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -59,7 +59,7 @@ export default function Home() {
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-center p-8 bg-gray-50">
-      <main className="max-w-2xl w-full space-y-8">
+      <main className="max-w-4xl w-full space-y-8">
         <div className="text-center">
           <h1 className="text-4xl font-bold text-gray-900 mb-4">
             Welcome to Your Self-Hosted Application!
@@ -70,73 +70,88 @@ export default function Home() {
         </div>
 
         <div className="bg-white p-6 rounded-lg shadow-md">
-          <button
-            onClick={testApi}
-            disabled={loading}
-            className="w-full bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 transition-colors disabled:bg-blue-400"
-          >
-            {loading ? 'Testing API...' : 'Test API Connection'}
-          </button>
-
-          <button
-            onClick={testDb}
-            disabled={loading}
-            className="w-full bg-green-600 text-white py-2 px-4 rounded-md hover:bg-green-700 transition-colors disabled:bg-green-400 mt-4"
-          >
-            {loading ? 'Testing DB...' : 'Test DB Connection'}
-          </button>
-
-          <button
-            onClick={testCassandra}
-            disabled={loading}
-            className="w-full bg-yellow-600 text-white py-2 px-4 rounded-md hover:bg-yellow-700 transition-colors disabled:bg-yellow-400 mt-4"
-          >
-            {loading ? 'Testing Cassandra...' : 'Test Cassandra Connection'}
-          </button>
-
-          <button
-            onClick={testElastic}
-            disabled={loading}
-            className="w-full bg-teal-600 text-white py-2 px-4 rounded-md hover:bg-teal-700 transition-colors disabled:bg-teal-400 mt-4"
-          >
-            {loading ? 'Testing Elasticsearch...' : 'Test Elasticsearch Connection'}
-          </button>
-
-          {apiResponse && (
-            <div className="mt-4 p-4 bg-gray-50 rounded-md">
-              <h2 className="text-lg font-semibold mb-2">API Response:</h2>
-              <pre className="whitespace-pre-wrap text-sm">
-                {JSON.stringify(apiResponse, null, 2)}
-              </pre>
-            </div>
-          )}
-
-          {dbResponse && (
-            <div className="mt-4 p-4 bg-gray-50 rounded-md">
-              <h2 className="text-lg font-semibold mb-2">DB API Response:</h2>
-              <pre className="whitespace-pre-wrap text-sm">
-                {JSON.stringify(dbResponse, null, 2)}
-              </pre>
-            </div>
-          )}
-
-          {cassandraResponse && (
-            <div className="mt-4 p-4 bg-gray-50 rounded-md">
-              <h2 className="text-lg font-semibold mb-2">Cassandra API Response:</h2>
-              <pre className="whitespace-pre-wrap text-sm">
-                {JSON.stringify(cassandraResponse, null, 2)}
-              </pre>
-            </div>
-          )}
-
-          {elasticResponse && (
-            <div className="mt-4 p-4 bg-gray-50 rounded-md">
-              <h2 className="text-lg font-semibold mb-2">Elasticsearch API Response:</h2>
-              <pre className="whitespace-pre-wrap text-sm">
-                {JSON.stringify(elasticResponse, null, 2)}
-              </pre>
-            </div>
-          )}
+          <table className="w-full">
+            <thead>
+              <tr className="text-left">
+                <th className="p-4">Test</th>
+                <th className="p-4">Result</th>
+              </tr>
+            </thead>
+            <tbody>
+              <tr className="border-t">
+                <td className="p-4">
+                  <button
+                    onClick={testApi}
+                    disabled={loading}
+                    className="bg-blue-600 text-white py-2 px-4 rounded-md hover:bg-blue-700 transition-colors disabled:bg-blue-400"
+                  >
+                    {loading ? 'Testing...' : 'Test API'}
+                  </button>
+                </td>
+                <td className="p-4">
+                  {apiResponse && (
+                    <pre className="whitespace-pre-wrap text-sm bg-gray-50 p-2 rounded-md">
+                      {JSON.stringify(apiResponse, null, 2)}
+                    </pre>
+                  )}
+                </td>
+              </tr>
+              <tr className="border-t">
+                <td className="p-4">
+                  <button
+                    onClick={testDb}
+                    disabled={loading}
+                    className="bg-green-600 text-white py-2 px-4 rounded-md hover:bg-green-700 transition-colors disabled:bg-green-400"
+                  >
+                    {loading ? 'Testing...' : 'Test DB'}
+                  </button>
+                </td>
+                <td className="p-4">
+                  {dbResponse && (
+                    <pre className="whitespace-pre-wrap text-sm bg-gray-50 p-2 rounded-md">
+                      {JSON.stringify(dbResponse, null, 2)}
+                    </pre>
+                  )}
+                </td>
+              </tr>
+              <tr className="border-t">
+                <td className="p-4">
+                  <button
+                    onClick={testCassandra}
+                    disabled={loading}
+                    className="bg-yellow-600 text-white py-2 px-4 rounded-md hover:bg-yellow-700 transition-colors disabled:bg-yellow-400"
+                  >
+                    {loading ? 'Testing...' : 'Test Cassandra'}
+                  </button>
+                </td>
+                <td className="p-4">
+                  {cassandraResponse && (
+                    <pre className="whitespace-pre-wrap text-sm bg-gray-50 p-2 rounded-md">
+                      {JSON.stringify(cassandraResponse, null, 2)}
+                    </pre>
+                  )}
+                </td>
+              </tr>
+              <tr className="border-t">
+                <td className="p-4">
+                  <button
+                    onClick={testElastic}
+                    disabled={loading}
+                    className="bg-teal-600 text-white py-2 px-4 rounded-md hover:bg-teal-700 transition-colors disabled:bg-teal-400"
+                  >
+                    {loading ? 'Testing...' : 'Test Elasticsearch'}
+                  </button>
+                </td>
+                <td className="p-4">
+                  {elasticResponse && (
+                    <pre className="whitespace-pre-wrap text-sm bg-gray-50 p-2 rounded-md">
+                      {JSON.stringify(elasticResponse, null, 2)}
+                    </pre>
+                  )}
+                </td>
+              </tr>
+            </tbody>
+          </table>
         </div>
       </main>
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,8 @@ export default function Home() {
   const [apiResponse, setApiResponse] = useState<any>(null);
   const [loading, setLoading] = useState(false);
   const [dbResponse, setDbResponse] = useState<any>(null);
+  const [cassandraResponse, setCassandraResponse] = useState<any>(null);
+  const [elasticResponse, setElasticResponse] = useState<any>(null);
 
   const testApi = async () => {
     setLoading(true);
@@ -27,6 +29,30 @@ export default function Home() {
       setDbResponse(data);
     } catch (error) {
       setDbResponse({ error: 'Failed to fetch from DB API' });
+    }
+    setLoading(false);
+  };
+
+  const testCassandra = async () => {
+    setLoading(true);
+    try {
+      const response = await fetch('/api/cassandratest');
+      const data = await response.json();
+      setCassandraResponse(data);
+    } catch (error) {
+      setCassandraResponse({ error: 'Failed to fetch from Cassandra API' });
+    }
+    setLoading(false);
+  };
+
+  const testElastic = async () => {
+    setLoading(true);
+    try {
+      const response = await fetch('/api/elastictest');
+      const data = await response.json();
+      setElasticResponse(data);
+    } catch (error) {
+      setElasticResponse({ error: 'Failed to fetch from Elastic API' });
     }
     setLoading(false);
   };
@@ -60,6 +86,22 @@ export default function Home() {
             {loading ? 'Testing DB...' : 'Test DB Connection'}
           </button>
 
+          <button
+            onClick={testCassandra}
+            disabled={loading}
+            className="w-full bg-yellow-600 text-white py-2 px-4 rounded-md hover:bg-yellow-700 transition-colors disabled:bg-yellow-400 mt-4"
+          >
+            {loading ? 'Testing Cassandra...' : 'Test Cassandra Connection'}
+          </button>
+
+          <button
+            onClick={testElastic}
+            disabled={loading}
+            className="w-full bg-teal-600 text-white py-2 px-4 rounded-md hover:bg-teal-700 transition-colors disabled:bg-teal-400 mt-4"
+          >
+            {loading ? 'Testing Elasticsearch...' : 'Test Elasticsearch Connection'}
+          </button>
+
           {apiResponse && (
             <div className="mt-4 p-4 bg-gray-50 rounded-md">
               <h2 className="text-lg font-semibold mb-2">API Response:</h2>
@@ -74,6 +116,24 @@ export default function Home() {
               <h2 className="text-lg font-semibold mb-2">DB API Response:</h2>
               <pre className="whitespace-pre-wrap text-sm">
                 {JSON.stringify(dbResponse, null, 2)}
+              </pre>
+            </div>
+          )}
+
+          {cassandraResponse && (
+            <div className="mt-4 p-4 bg-gray-50 rounded-md">
+              <h2 className="text-lg font-semibold mb-2">Cassandra API Response:</h2>
+              <pre className="whitespace-pre-wrap text-sm">
+                {JSON.stringify(cassandraResponse, null, 2)}
+              </pre>
+            </div>
+          )}
+
+          {elasticResponse && (
+            <div className="mt-4 p-4 bg-gray-50 rounded-md">
+              <h2 className="text-lg font-semibold mb-2">Elasticsearch API Response:</h2>
+              <pre className="whitespace-pre-wrap text-sm">
+                {JSON.stringify(elasticResponse, null, 2)}
               </pre>
             </div>
           )}


### PR DESCRIPTION
Adds new API routes and dependencies to test the connection to Cassandra and Elasticsearch. This will allow for verification that the application can access and use the credentials from the Kubernetes secret.