### PR TITLE
fix: Elasticsearch SSL verification with CA certificate

### DIFF
--- a/flux/manifests/deployment.yaml
+++ b/flux/manifests/deployment.yaml
@@ -40,3 +40,14 @@ spec:
           envFrom:
             - secretRef:
                 name: example-self-hosted-saas-app-secrets
+          volumeMounts:
+            - name: elasticsearch-ca-cert
+              mountPath: /etc/ssl/certs/elasticsearch-ca.crt
+              subPath: ca.crt
+      volumes:
+        - name: elasticsearch-ca-cert
+          secret:
+            secretName: example-self-hosted-saas-app-secrets
+            items:
+              - key: ELASTICSEARCH_CA_CRT
+                path: ca.crt

--- a/src/app/api/cassandratest/route.ts
+++ b/src/app/api/cassandratest/route.ts
@@ -14,11 +14,13 @@ export async function GET() {
 
     try {
         await client.connect();
-        const result = await client.execute('SELECT * FROM system.local');
+        const result = await client.execute('SELECT cluster_name, release_version, cql_version FROM system.local');
         await client.shutdown();
         return NextResponse.json({
             message: 'Cassandra connection successful!',
-            dbResult: result.rows,
+            clusterName: result.rows[0].cluster_name,
+            cassandraVersion: result.rows[0].release_version,
+            cqlVersion: result.rows[0].cql_version,
             status: 'success',
             timestamp: new Date().toISOString(),
         });

--- a/src/app/api/elastictest/route.ts
+++ b/src/app/api/elastictest/route.ts
@@ -1,12 +1,23 @@
 import { NextResponse } from 'next/server';
 import { Client } from '@elastic/elasticsearch';
+import fs from 'fs';
 
 export async function GET() {
+    let caCert: string | undefined;
+    try {
+        caCert = fs.readFileSync('/etc/ssl/certs/elasticsearch-ca.crt', 'utf8');
+    } catch (error) {
+        console.error('Failed to read CA certificate:', error);
+    }
+
     const client = new Client({
         node: `http${process.env.ELASTICSEARCH_SECURE === 'true' ? 's' : ''}://${process.env.ELASTICSEARCH_HOST}:${process.env.ELASTICSEARCH_PORT}`,
         auth: {
             username: process.env.ELASTICSEARCH_USER!,
             password: process.env.ELASTICSEARCH_PASSWORD!
+        },
+        tls: {
+            ca: caCert
         }
     });
 


### PR DESCRIPTION
Configures the Elasticsearch client to use the provided CA certificate for SSL verification, resolving the "unable to verify the first certificate" error. The CA certificate is mounted from a Kubernetes secret into the application container.